### PR TITLE
Fix typo in docker buildx push

### DIFF
--- a/.github/workflows/buildpush.yml
+++ b/.github/workflows/buildpush.yml
@@ -72,7 +72,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs_tags }}
+          tags: ${{ steps.prep.outputs.tags }}
           platforms: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/s390x
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
Broke `tags`, resulting in:

```
tag is needed when pushing to registry
Error: The process '/usr/bin/docker' failed with exit code 1
```