### PR TITLE
Fix docker image name to include ghcr.io/

### DIFF
--- a/.github/workflows/buildpush.yml
+++ b/.github/workflows/buildpush.yml
@@ -8,7 +8,13 @@ on:
       - master
     tags:
       - 'v*.*.*'
+    paths-ignore:
+      - '**.md'
   pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
 
 jobs:
   main:
@@ -17,7 +23,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=${{ github.repository_owner }}/myshell
+          DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/myshell
           VERSION=noop
           if [ "${{ github.event_name }}" = "schedule" ]; then
             VERSION=nightly
@@ -54,6 +60,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           registry: ghcr.io


### PR DESCRIPTION
Duh. Docker needs to tag the image with ghcr.io/ prefix before it will
push to ghcr.io (because you know, image identity is location, or something?)