### PR TITLE
Update GitHub Actions runner to Ubuntu 22.04

### DIFF
--- a/.github/workflows/buildpush.yml
+++ b/.github/workflows/buildpush.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   main:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
Hopefully this fixes qemu crashes